### PR TITLE
Improve the error handling

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,7 +2,15 @@ use switchbot_cli::Cli;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    env_logger::init();
+    if std::env::var("RUST_LOG").is_ok() {
+        env_logger::init();
+    } else {
+        env_logger::Builder::new()
+            .format_timestamp(None)
+            .format_target(false)
+            .filter_level(log::LevelFilter::Info)
+            .init();
+    }
 
     let mut cli = Cli::new_from_args();
     cli.run().await?;


### PR DESCRIPTION
* Errors while executing commands are now properly handled and
  send to log instead of quitting the application.
* Initialize the `env_logger` to use a more user-friendly
  format unless the `RUST_LOG` environment variable is set.
* Tighten the error check of the device number.
