### PR TITLE
Fix handling SwitchBot API command error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,6 +1374,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "thiserror",
  "tokio",
  "uuid",
 ]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -20,3 +20,4 @@ serde_json = "1.0.140"
 serde = { version = "1.0.219", features = ["derive"] }
 log = "0.4.27"
 anyhow = { version = "1.0.98", features = ["backtrace"] }
+thiserror = "2.0.12"

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -20,5 +20,5 @@ pub use device_list::*;
 mod switch_bot;
 pub use switch_bot::*;
 mod switch_bot_service;
-pub use switch_bot_service::CommandRequest;
 pub(crate) use switch_bot_service::*;
+pub use switch_bot_service::{CommandRequest, SwitchBotError};


### PR DESCRIPTION
* Support cases when the response doesn't have a `body`.
* Add the `SwitchBotError` to pass `status_code` and `message`
  from the SwitchBot API server.
