### PR TITLE
CLI: Allow the alias option `-a` in the batch mode

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -54,10 +54,17 @@ impl Cli {
     }
 
     pub async fn run(&mut self) -> anyhow::Result<()> {
+        self.run_core().await?;
+        self.args.save()?;
+        Ok(())
+    }
+
+    async fn run_core(&mut self) -> anyhow::Result<()> {
         if !self.args.alias_updates.is_empty() {
             self.args.print_aliases();
-            self.args.save()?;
-            return Ok(());
+            if self.args.commands.is_empty() {
+                return Ok(());
+            }
         }
 
         self.switch_bot = self.args.create_switch_bot()?;
@@ -65,13 +72,10 @@ impl Cli {
 
         if !self.args.commands.is_empty() {
             self.execute_args(&self.args.commands.clone()).await?;
-            self.args.save()?;
             return Ok(());
         }
 
         self.run_interactive().await?;
-
-        self.args.save()?;
         Ok(())
     }
 


### PR DESCRIPTION
The following example is allowed with this change:
```shell-session
switchbot -a a=b 4 on
```
