### PR TITLE
Parallelize only when multiple devices are selected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "switchbot-api"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "base64",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "switchbot-cli"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "async-scoped",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["api", "cli"]
 exclude = [".github", ".gitignore", "hooks", ".vscode"]
 
 [workspace.package]
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 authors = ["Koji Ishii <kojiishi@gmail.com>"]
 description = "Command line tool and library to interact with the SwitchBot API."

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -26,6 +26,11 @@ pub struct Args {
     #[serde(skip)]
     pub alias_updates: Vec<String>,
 
+    /// The minimum number of tasks to parallelize.
+    #[arg(short = 'P', long, default_value_t = 2)]
+    #[serde(skip)]
+    pub parallel_threshold: usize,
+
     #[arg(skip)]
     #[serde(default)]
     pub aliases: HashMap<String, String>,


### PR DESCRIPTION
The parallel execution in #39 has some overheads that using the code path for single task may not be efficient.

This patch changes to choose the single or parallel code path depending on the number of selected devices.
