### PR TITLE
Add `devices` built-in command

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -179,6 +179,13 @@ prepend it with a `/` (slash) as the separator.
 Command> customize/button1
 ```
 
+### Built-in Commands
+
+Following commands are executed by the `switchbot` command itself.
+* The `devices` command prints all devices.
+* The [`status`][status] and the [`status.key`][status-key] commands
+  query the device status.
+
 ## Aliases
 [aliases]: #aliases
 
@@ -218,6 +225,7 @@ fanSpeed: 23
 [get-device-status]: https://github.com/OpenWonderLabs/SwitchBotAPI#get-device-status
 
 ### Status of a Key
+[status-key]: #status-of-a-key
 
 It is also possible to check the status of a specific key
 by specifying `status.` (status dot) followed by the key name.

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -26,11 +26,6 @@ pub struct Args {
     #[serde(skip)]
     pub alias_updates: Vec<String>,
 
-    /// List the devices.
-    #[arg(short, long)]
-    #[serde(skip)]
-    pub list_devices: bool,
-
     /// The minimum number of tasks to parallelize.
     #[arg(short = 'P', long, default_value_t = 2)]
     #[serde(skip)]


### PR DESCRIPTION
This command prints all devices.

Removes the `-l` option in favor to the built-in command.
