### PR TITLE
Change `if`-command to call `execute` recursively

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -224,11 +224,7 @@ impl Cli {
                 else_command
             };
             log::debug!("if: {condition} is {eval_result}, execute {command}");
-            if let Some(alias) = self.args.aliases.get(command) {
-                self.execute_command(alias.as_str()).await?;
-            } else {
-                self.execute_command(command).await?;
-            }
+            Box::pin(self.execute(command)).await?;
             return Ok(true);
         }
         Ok(false)


### PR DESCRIPTION
This allows the `then` or `else` parts to use device selections and a few other things not in `execute_command`.
